### PR TITLE
[step14] 대기열 로직 Redis로 이관

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ docker-compose up -d
 ### 7. [아키텍처 설계](https://github.com/yangahh/concert-ticket-reservation/wiki/7.-%EC%95%84%ED%82%A4%ED%85%8D%EC%B3%90-%EA%B5%AC%EC%A1%B0-%EC%84%A4%EA%B3%84)
 ### 8. [콘서트 예매 서비스의 동시성 문제 파악 및 최적화 방안 탐색](https://github.com/yangahh/concert-ticket-reservation/wiki/8.-%EB%8F%99%EC%8B%9C%EC%84%B1-%EC%9D%B4%EC%8A%88%EC%97%90-%EB%8C%80%ED%95%9C-%EB%B6%84%EC%84%9D)
 ### 9. [캐시 도입에 관한 보고서](https://massive-turn-bcc.notion.site/1-19104128f9578001a565c14f02c7e449)
+### 10. [대기열 로직 RDB에서 Redis로 이관에 관한 보고서](https://massive-turn-bcc.notion.site/RDB-Redis-19104128f95780188851c1e0099f1a86?pvs=4)

--- a/src/main/java/kr/hhplus/be/server/application/payment/usecase/PaymentUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/application/payment/usecase/PaymentUseCase.java
@@ -1,6 +1,5 @@
 package kr.hhplus.be.server.application.payment.usecase;
 
-import jakarta.persistence.OptimisticLockException;
 import kr.hhplus.be.server.domain.common.exception.UnprocessableEntityException;
 import kr.hhplus.be.server.domain.concert.service.ConcertService;
 import kr.hhplus.be.server.domain.point.service.PointService;
@@ -39,7 +38,7 @@ public class PaymentUseCase {
 
             ReservationResult reservationResult = reservationService.confirmReservation(reservationId, now);
             pointService.usePoint(reservationResult.userId(), reservationResult.price(), reservationId);
-            queueTokenService.deleteToken(tokenUuid);
+            queueTokenService.deleteToken(reservationResult.concertScheduleResult().concertId(), tokenUuid);
 
             return reservationResult;
 

--- a/src/main/java/kr/hhplus/be/server/application/queuetoken/scheduler/ActivateTokenScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/application/queuetoken/scheduler/ActivateTokenScheduler.java
@@ -19,10 +19,13 @@ public class ActivateTokenScheduler {
 
     @Scheduled(fixedRate = 10000)  // 10초마다 실행
     public void execute() {
+        log.info("==============================ActivateTokenScheduler================================");
+        log.info("Started at {}", LocalDateTime.now());
         List<Long> allConcertIds = concertService.getAllConcertIds();
         for (Long concertId : allConcertIds) {
+            log.info("For ConcertId '{}'", concertId);
             queueTokenService.activateTokens(concertId);
-            log.info("ActivateTokenScheduler for concertId '{}' is running at {}", concertId, LocalDateTime.now());
         }
+        log.info("==============================ActivateTokenScheduler End================================");
     }
 }

--- a/src/main/java/kr/hhplus/be/server/application/queuetoken/scheduler/ActivateTokenScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/application/queuetoken/scheduler/ActivateTokenScheduler.java
@@ -1,5 +1,6 @@
 package kr.hhplus.be.server.application.queuetoken.scheduler;
 
+import kr.hhplus.be.server.domain.concert.service.ConcertService;
 import kr.hhplus.be.server.domain.queuetoken.service.QueueTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -7,16 +8,21 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ActivateTokenScheduler {
     private final QueueTokenService queueTokenService;
+    private final ConcertService concertService;
 
-    @Scheduled(fixedDelay = 3000)  // 이전 실행이 끝나고 3초 후 실행
+    @Scheduled(fixedRate = 10000)  // 10초마다 실행
     public void execute() {
-        queueTokenService.activateTokens();
-        log.info("ActivateTokenScheduler is running at {}", LocalDateTime.now());
+        List<Long> allConcertIds = concertService.getAllConcertIds();
+        for (Long concertId : allConcertIds) {
+            queueTokenService.activateTokens(concertId);
+            log.info("ActivateTokenScheduler for concertId '{}' is running at {}", concertId, LocalDateTime.now());
+        }
     }
 }

--- a/src/main/java/kr/hhplus/be/server/application/reservation/scheduler/CancelExpiredTempReservationScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/application/reservation/scheduler/CancelExpiredTempReservationScheduler.java
@@ -24,8 +24,16 @@ public class CancelExpiredTempReservationScheduler {
     @Transactional
     public void handleExpiredReservations() {
         LocalDateTime now = timeProvider.now();
+        log.info("==============================CancelExpiredTempReservations================================");
+        log.info("Started at {}", now);
         List<Long> expiredSeatIds = reservationService.cancelExpiredTempReservations(now);
-        seatService.releaseSeats(expiredSeatIds);
-        log.info("CancelExpiredTempReservationScheduler is running at {}", now);
+
+        if (expiredSeatIds.isEmpty()) {
+            log.info("No expired reservations");
+        } else {
+            seatService.releaseSeats(expiredSeatIds);
+            log.info("Released {} seats", expiredSeatIds.size());
+        }
+        log.info("==============================CancelExpiredTempReservations End================================");
     }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/concert/repository/ConcertRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/concert/repository/ConcertRepository.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 public interface ConcertRepository {
     Page<Concert> findConcertsAfterDate(LocalDate date, int offset, int limit);
 
+    List<Concert> findAllConcert();
+
     Optional<Concert> findConcertById(Long concertId);
 
     Optional<ConcertSchedule> findConcertScheduleById(Long concertScheduleId);

--- a/src/main/java/kr/hhplus/be/server/domain/concert/service/ConcertService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/concert/service/ConcertService.java
@@ -6,6 +6,7 @@ import kr.hhplus.be.server.domain.concert.dto.ConcertSchedulesResult;
 import kr.hhplus.be.server.domain.concert.dto.ConcertSeatsResult;
 import kr.hhplus.be.server.domain.concert.dto.ConcertsResult;
 import kr.hhplus.be.server.domain.concert.dto.ReservationSeatInfo;
+import kr.hhplus.be.server.domain.concert.entity.Concert;
 import kr.hhplus.be.server.domain.concert.entity.ConcertSchedule;
 import kr.hhplus.be.server.domain.concert.entity.Seat;
 import kr.hhplus.be.server.domain.concert.repository.ConcertRepository;
@@ -32,6 +33,13 @@ public class ConcertService {
     @Cacheable(value = "getConcertsAfterDate", key = "'concert:' + #date + ':offset:' + #offset + ':limit:' + #limit", cacheManager = "concertCacheManager")
     public ConcertsResult getConcertsAfterDate(LocalDate date, int offset, int limit) {
         return ConcertsResult.fromPage(concertRepository.findConcertsAfterDate(date, offset, limit));
+    }
+
+    public List<Long> getAllConcertIds() {
+        List<Concert> allConcert = concertRepository.findAllConcert();
+        return allConcert.stream()
+                .map(Concert::getId)
+                .toList();
     }
 
     public ConcertSchedulesResult getConcertSchedules(

--- a/src/main/java/kr/hhplus/be/server/domain/queuetoken/dto/QueueTokenPositionResult.java
+++ b/src/main/java/kr/hhplus/be/server/domain/queuetoken/dto/QueueTokenPositionResult.java
@@ -8,11 +8,11 @@ import java.util.UUID;
 @Builder
 public record QueueTokenPositionResult (
         UUID tokenUuid,
-        long userId,
-        long concertId,
-        int position,
-        int remainingSeconds,
-        boolean isActive
+        Long userId,
+        Long concertId,
+        Integer position,
+        Integer remainingSeconds,
+        Boolean isActive
 ) {
     public static QueueTokenPositionResult fromEntity(QueueToken entity, int position, int remainingSeconds) {
         return QueueTokenPositionResult.builder()

--- a/src/main/java/kr/hhplus/be/server/domain/queuetoken/entity/QueueToken.java
+++ b/src/main/java/kr/hhplus/be/server/domain/queuetoken/entity/QueueToken.java
@@ -24,7 +24,6 @@ public class QueueToken {
     @Column(name = "token_uuid", unique = true, nullable = false, updatable = false, columnDefinition = "BINARY(16)")
     private UUID tokenUuid;
 
-    @NotNull
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
@@ -36,11 +35,9 @@ public class QueueToken {
     @Column(name = "is_active", nullable = false)
     private boolean isActive;
 
-    @NotNull
     @Column(name = "created_at", updatable = false, columnDefinition = "TIMESTAMP(6)")
     private LocalDateTime createdAt;
 
-    @NotNull
     @Column(name = "expired_at", updatable = false, columnDefinition = "TIMESTAMP(6)")
     private LocalDateTime expiredAt;
 
@@ -66,6 +63,14 @@ public class QueueToken {
                 .build();
     }
 
+    public static QueueToken fromRedis(Long concertId, UUID tokenUuid, boolean isActive) {
+        return QueueToken.builder()
+            .tokenUuid(tokenUuid)
+            .concertId(concertId)
+            .isActive(isActive)
+            .build();
+    }
+
     public void activate() {
         if (!isActive) {
             this.isActive = true;
@@ -73,6 +78,7 @@ public class QueueToken {
     }
 
     public boolean isExpired(TimeProvider timeProvider) {
+        if (expiredAt == null) return false;  // Redis에서 가져온 경우 만료된 경우는 Redis에 없기 때문에 항상 isExpired가 false가 됨
         return timeProvider.now().isAfter(expiredAt);
     }
 

--- a/src/main/java/kr/hhplus/be/server/domain/queuetoken/repository/QueueTokenRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/queuetoken/repository/QueueTokenRepository.java
@@ -2,25 +2,21 @@ package kr.hhplus.be.server.domain.queuetoken.repository;
 
 import kr.hhplus.be.server.domain.queuetoken.entity.QueueToken;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface QueueTokenRepository {
     QueueToken save(QueueToken queueToken);
 
-    Optional<QueueToken> findByTokenUuid(UUID tokenUuid);
+    Optional<QueueToken> findByConcertIdAndTokenUuid(Long concertId, UUID tokenUuid);
 
-    void deleteExpiredTokens();
+    int countActiveTokens(Long concertId);
 
-    int countActiveTokens();
+    void deleteExpiredTokens(Long concertId);
 
-    List<Long> findOldestWaitingTokensIds(int limit);
+    void activateTokensByConcertId(Long concertId, int countToActivate);
 
-    void updateOldestWaitingTokensToActive(List<Long> ids);
+    int countWaitingTokensAhead(QueueToken queueToken);
 
-    int countWaitingTokensAhead(Long concertId, LocalDateTime referenceCreatedAt);
-
-    void deleteByUuid(UUID tokenUuid);
+    void deleteByConcertIdAndUuid(Long concertId, UUID tokenUuid);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/queuetoken/service/QueueTokenService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/queuetoken/service/QueueTokenService.java
@@ -66,7 +66,7 @@ public class QueueTokenService {
         queueTokenRepository.deleteExpiredTokens(concertId);
 
         int activeTokenCount = queueTokenRepository.countActiveTokens(concertId);
-        if (activeTokenCount >= ACTIVE_TOKEN_MAX_COUNT) {
+        if (activeTokenCount + CONVERT_RATE_PER_10_SECONDS > ACTIVE_TOKEN_MAX_COUNT) {
             return;
         }
         queueTokenRepository.activateTokensByConcertId(concertId, CONVERT_RATE_PER_10_SECONDS);

--- a/src/main/java/kr/hhplus/be/server/infrastructure/concert/repository/ConcertRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/concert/repository/ConcertRepositoryImpl.java
@@ -30,6 +30,11 @@ public class ConcertRepositoryImpl implements ConcertRepository {
     }
 
     @Override
+    public List<Concert> findAllConcert() {
+        return concertJpaRepository.findAll();
+    }
+
+    @Override
     public Optional<Concert> findConcertById(Long concertId) {
         return concertJpaRepository.findById(concertId);
     }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/queuetoken/repository/ActiveTokenRedisTemplate.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/queuetoken/repository/ActiveTokenRedisTemplate.java
@@ -1,0 +1,45 @@
+package kr.hhplus.be.server.infrastructure.queuetoken.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Component
+public class ActiveTokenRedisTemplate {
+    private final ZSetOperations<String, Object> zSetOperations;
+
+    public ActiveTokenRedisTemplate(RedisTemplate<String, Object> redisTemplate) {
+        this.zSetOperations = redisTemplate.opsForZSet();
+    }
+
+    public static String getKey(Long concertId) {
+        return "active:concert:" + concertId;
+    }
+
+    public Boolean add(Long concertId, UUID tokenUuid, Double score) {
+        return zSetOperations.add(getKey(concertId), tokenUuid, score);
+    }
+
+    public Double getScore(Long concertId, UUID tokenUuid) {
+        return zSetOperations.score(getKey(concertId), tokenUuid);
+    }
+
+    public Long size(Long concertId) {
+        return zSetOperations.size(getKey(concertId));
+    }
+
+    public Long remove(Long concertId, UUID tokenUuid) {
+        return zSetOperations.remove(getKey(concertId), tokenUuid);
+    }
+
+    public void removeRangeByScore(Long concertId, double min, double max) {
+        zSetOperations.removeRangeByScore(getKey(concertId), min, max);
+    }
+
+    public Set<ZSetOperations.TypedTuple<Object>> rangeWithScores(Long concertId, long start, long end) {
+        return zSetOperations.rangeWithScores(getKey(concertId), start, end);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/queuetoken/repository/QueueTokenJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/queuetoken/repository/QueueTokenJpaRepository.java
@@ -22,7 +22,7 @@ public interface QueueTokenJpaRepository extends JpaRepository<QueueToken, Long>
     @Modifying(clearAutomatically = true)
     void deleteByExpiredAtBefore(LocalDateTime datetime);
 
-    int countByIsActive(boolean isActive);
+    int countByConcertIdAndIsActive(Long concertId, boolean isActive);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT qt.id FROM QueueToken qt WHERE qt.isActive = false ORDER BY qt.createdAt ASC")

--- a/src/main/java/kr/hhplus/be/server/infrastructure/queuetoken/repository/QueueTokenRedisRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/queuetoken/repository/QueueTokenRedisRepositoryImpl.java
@@ -1,0 +1,83 @@
+package kr.hhplus.be.server.infrastructure.queuetoken.repository;
+
+import kr.hhplus.be.server.domain.queuetoken.entity.QueueToken;
+import kr.hhplus.be.server.domain.queuetoken.repository.QueueTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+@Component
+@Primary
+@RequiredArgsConstructor
+public class QueueTokenRedisRepositoryImpl implements QueueTokenRepository {
+    private final WaitingTokenRedisTemplate waitingTokenRedisTemplate;
+    private final ActiveTokenRedisTemplate activeTokenRedisTemplate;
+
+    @Override
+    public QueueToken save(QueueToken queueToken) {
+        double expiredTimeStamp = (double) queueToken.getExpiredAt().atZone(ZoneOffset.UTC).toInstant().toEpochMilli();
+
+        if (queueToken.isActive()) {
+            activeTokenRedisTemplate.add(queueToken.getConcertId(), queueToken.getTokenUuid(), expiredTimeStamp);
+        } else {
+            waitingTokenRedisTemplate.add(queueToken.getConcertId(), queueToken.getTokenUuid(), expiredTimeStamp);
+        }
+        return queueToken;
+    }
+
+    @Override
+    public Optional<QueueToken> findByConcertIdAndTokenUuid(Long concertId, UUID tokenUuid) {
+        Double waitingScore = waitingTokenRedisTemplate.getScore(concertId, tokenUuid);
+        if (waitingScore != null) {
+            return Optional.of(QueueToken.fromRedis(concertId, tokenUuid, false));
+        }
+
+        Double activeScore = activeTokenRedisTemplate.getScore(concertId, tokenUuid);
+        if (activeScore != null) {
+            return Optional.of(QueueToken.fromRedis(concertId, tokenUuid, true));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public int countWaitingTokensAhead(QueueToken queueToken) {
+        return waitingTokenRedisTemplate.getRank(queueToken.getConcertId(), queueToken.getTokenUuid()).intValue();
+    }
+
+    @Override
+    public int countActiveTokens(Long concertId) {
+        return activeTokenRedisTemplate.size(concertId).intValue();
+    }
+
+    @Override
+    public void activateTokensByConcertId(Long concertId, int countToActivate) {
+        Set<TypedTuple<Object>> result = waitingTokenRedisTemplate.popMin(concertId, countToActivate);
+
+        for (TypedTuple<Object> tuple : result) {
+            double expiredTimeStamp = (double) Instant.now().plus(Duration.ofMinutes(10)).toEpochMilli();
+            UUID tokenUuid = UUID.fromString(tuple.getValue().toString());
+            activeTokenRedisTemplate.add(concertId, tokenUuid, expiredTimeStamp);
+        }
+    }
+
+    @Override
+    public void deleteByConcertIdAndUuid(Long concertId, UUID tokenUuid) {
+        activeTokenRedisTemplate.remove(concertId, tokenUuid);
+    }
+
+    @Override
+    public void deleteExpiredTokens(Long concertId) {
+        long currentTime = Instant.now().toEpochMilli();
+
+        waitingTokenRedisTemplate.removeRangeByScore(concertId, 0, currentTime);
+        activeTokenRedisTemplate.removeRangeByScore(concertId, 0, currentTime);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/queuetoken/repository/WaitingTokenRedisTemplate.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/queuetoken/repository/WaitingTokenRedisTemplate.java
@@ -1,0 +1,54 @@
+package kr.hhplus.be.server.infrastructure.queuetoken.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Component
+public class WaitingTokenRedisTemplate {
+    private final ZSetOperations<String, Object> zSetOperations;
+
+    public WaitingTokenRedisTemplate(RedisTemplate<String, Object> redisTemplate) {
+        this.zSetOperations = redisTemplate.opsForZSet();
+    }
+
+    public static String getKey(Long concertId) {
+        return "waiting:concert:" + concertId;
+    }
+
+    public Boolean add(Long concertId, UUID tokenUuid, Double score) {
+        return zSetOperations.add(getKey(concertId), tokenUuid, score);
+    }
+
+    public Double getScore(Long concertId, UUID tokenUuid) {
+        return zSetOperations.score(getKey(concertId), tokenUuid);
+    }
+
+    public Long size(Long concertId) {
+        return zSetOperations.size(getKey(concertId));
+    }
+
+    public Long getRank(Long concertId, UUID tokenUuid) {
+        return zSetOperations.rank(getKey(concertId), tokenUuid);
+    }
+
+    public Set<TypedTuple<Object>> popMin(Long concertId, int count) {
+        return zSetOperations.popMin(getKey(concertId), count);
+    }
+
+    public void removeRangeByScore(Long concertId, double min, double max) {
+        zSetOperations.removeRangeByScore(getKey(concertId), min, max);
+    }
+
+    public Set<Object> range(Long concertId, long start, long end) {
+        return zSetOperations.range(getKey(concertId), start, end);
+    }
+
+    public Set<TypedTuple<Object>> rangeWithScores(Long concertId, long start, long end) {
+        return zSetOperations.rangeWithScores(getKey(concertId), start, end);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/api/payment/controller/PaymentController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/api/payment/controller/PaymentController.java
@@ -7,6 +7,8 @@ import kr.hhplus.be.server.interfaces.api.common.dto.response.BaseResponse;
 import kr.hhplus.be.server.interfaces.api.payment.controller.apidocs.PaymentApiDocs;
 import kr.hhplus.be.server.interfaces.api.payment.dto.PaymentRequest;
 import kr.hhplus.be.server.interfaces.api.payment.dto.PaymentResponse;
+import kr.hhplus.be.server.interfaces.api.queuetoken.dto.QueueTokenCoreInfo;
+import kr.hhplus.be.server.interfaces.utils.queuetoken.QueueTokenDecoder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -25,7 +27,8 @@ public class PaymentController implements PaymentApiDocs {
     public ResponseEntity<BaseResponse<PaymentResponse>> processPayment(
             @RequestBody @Valid PaymentRequest request,
             @RequestHeader("X-Queue-Token") String token) {
-        ReservationResult result = paymentUseCase.payForReservation(request.getReservationId(), UUID.fromString(token));
+        QueueTokenCoreInfo decodedToken = QueueTokenDecoder.base64DecodeToken(token);
+        ReservationResult result = paymentUseCase.payForReservation(request.getReservationId(), decodedToken.tokenUuid());
         return ResponseEntity.ok(BaseResponse.ok(PaymentResponse.fromDomainDto(result)));
     }
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/api/queuetoken/controller/QueueTokenController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/api/queuetoken/controller/QueueTokenController.java
@@ -8,16 +8,16 @@ import kr.hhplus.be.server.domain.queuetoken.service.QueueTokenService;
 import kr.hhplus.be.server.interfaces.api.common.dto.response.BaseResponse;
 import kr.hhplus.be.server.interfaces.api.queuetoken.controller.apidocs.QueueTokenApiDocs;
 import kr.hhplus.be.server.interfaces.api.queuetoken.dto.QueuePositionResponse;
+import kr.hhplus.be.server.interfaces.api.queuetoken.dto.QueueTokenCoreInfo;
 import kr.hhplus.be.server.interfaces.api.queuetoken.dto.QueueTokenRequest;
 import kr.hhplus.be.server.interfaces.api.queuetoken.dto.QueueTokenResponse;
+import kr.hhplus.be.server.interfaces.utils.queuetoken.QueueTokenDecoder;
 import kr.hhplus.be.server.utils.regexp.Patterns;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.UUID;
 
 import static kr.hhplus.be.server.interfaces.api.common.exception.message.ExceptionMessage.INVALID_TOKEN_FORMAT;
 
@@ -38,8 +38,9 @@ public class QueueTokenController implements QueueTokenApiDocs {
     @Override
     @GetMapping("/position")
     public ResponseEntity<BaseResponse<QueuePositionResponse>> getWaitingTokenPosition(
-            @RequestParam("token") @Pattern(regexp = Patterns.UUID, message = INVALID_TOKEN_FORMAT) String token) {
-        QueueTokenPositionResult result = queueTokenService.getWaitingTokenPositionAndRemainingTime(UUID.fromString(token));
+            @RequestParam("token") @Pattern(regexp = Patterns.BASE64, message = INVALID_TOKEN_FORMAT) String token) {
+        QueueTokenCoreInfo decodedToken = QueueTokenDecoder.base64DecodeToken(token);
+        QueueTokenPositionResult result = queueTokenService.getWaitingTokenPositionAndRemainingTime(decodedToken.concertId(), decodedToken.tokenUuid());
         return ResponseEntity.ok(BaseResponse.ok(QueuePositionResponse.fromDomainDto(result)));
     }
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/api/queuetoken/controller/apidocs/QueueTokenApiDocs.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/api/queuetoken/controller/apidocs/QueueTokenApiDocs.java
@@ -33,5 +33,5 @@ public interface QueueTokenApiDocs {
     @ApiResponse(responseCode = "200", description = "OK")
     @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content( schema = @Schema(implementation = ErrorResponse.class, example = "{\"statusCode\":400,\"message\":\"잘못된 형식의 토큰값입니다.\"}")))
     ResponseEntity<BaseResponse<QueuePositionResponse>> getWaitingTokenPosition(
-            @RequestParam("token") @Pattern(regexp = Patterns.UUID, message = INVALID_TOKEN_FORMAT) String token);
+            @RequestParam("token") @Pattern(regexp = Patterns.BASE64, message = INVALID_TOKEN_FORMAT) String token);
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/api/queuetoken/dto/QueueTokenCoreInfo.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/api/queuetoken/dto/QueueTokenCoreInfo.java
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.interfaces.api.queuetoken.dto;
+
+import java.util.UUID;
+
+public record QueueTokenCoreInfo(
+    Long concertId,
+    UUID tokenUuid
+) { }

--- a/src/main/java/kr/hhplus/be/server/interfaces/api/queuetoken/dto/QueueTokenResponse.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/api/queuetoken/dto/QueueTokenResponse.java
@@ -2,23 +2,22 @@ package kr.hhplus.be.server.interfaces.api.queuetoken.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import kr.hhplus.be.server.domain.queuetoken.dto.QueueTokenResult;
+import kr.hhplus.be.server.interfaces.utils.queuetoken.QueueTokenEncoder;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.UUID;
 
 @Getter
 @Builder
 public class QueueTokenResponse {
-    @Schema(description = "발급된 대기열 토큰(uuid)", example = "157aadfa-96bb-4b1a-8127-d6e3dd31d72b")
-    private UUID token;
+    @Schema(description = "대기열 토큰 uuid와 concertId를 base64로 인코딩한 값", example = "MTU3YWFkZmEtOTZiYi00YjFhLTgxMjctZDZlM2RkMzFkNzJiOmFiYw==")
+    private String token;
 
     @Schema(description = "토큰 활성 여부", example = "false")
     private boolean isActive;
 
     public static QueueTokenResponse fromDomainDto(QueueTokenResult dto) {
         return QueueTokenResponse.builder()
-                .token(dto.tokenUuid())
+                .token(QueueTokenEncoder.base64EncodeToken(dto.tokenUuid(), dto.concertId()))
                 .isActive(dto.isActive())
                 .build();
     }

--- a/src/main/java/kr/hhplus/be/server/interfaces/utils/queuetoken/QueueTokenDecoder.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/utils/queuetoken/QueueTokenDecoder.java
@@ -19,10 +19,7 @@ public class QueueTokenDecoder {
         } catch (IllegalArgumentException e) {
             throw new InvalidToken("Invalid Base64 encoded token: " + encodedToken);
         } catch (JsonProcessingException e) {
-            if (e.getMessage().contains("uuid")) {
-                throw new InvalidToken("Invalid token format: " + encodedToken);
-            }
-            throw new RuntimeException(e);
+            throw new InvalidToken("Invalid token format: " + encodedToken);
         }
     }
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/utils/queuetoken/QueueTokenDecoder.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/utils/queuetoken/QueueTokenDecoder.java
@@ -1,0 +1,28 @@
+package kr.hhplus.be.server.interfaces.utils.queuetoken;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.domain.queuetoken.exception.InvalidToken;
+import kr.hhplus.be.server.interfaces.api.queuetoken.dto.QueueTokenCoreInfo;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class QueueTokenDecoder {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static QueueTokenCoreInfo base64DecodeToken(String encodedToken) {
+        try {
+            byte[] decodedBytes = Base64.getDecoder().decode(encodedToken);
+            String jsonString = new String(decodedBytes, StandardCharsets.UTF_8);
+            return objectMapper.readValue(jsonString, QueueTokenCoreInfo.class);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidToken("Invalid Base64 encoded token: " + encodedToken);
+        } catch (JsonProcessingException e) {
+            if (e.getMessage().contains("uuid")) {
+                throw new InvalidToken("Invalid token format: " + encodedToken);
+            }
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/utils/queuetoken/QueueTokenEncoder.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/utils/queuetoken/QueueTokenEncoder.java
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.interfaces.utils.queuetoken;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.interfaces.api.queuetoken.dto.QueueTokenCoreInfo;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
+
+public class QueueTokenEncoder {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static String base64EncodeToken(UUID tokenUuid, Long concertId) {
+        try {
+            QueueTokenCoreInfo coreInfo = new QueueTokenCoreInfo(concertId, tokenUuid);
+            String jsonString = objectMapper.writeValueAsString(coreInfo);
+
+            return Base64.getEncoder().encodeToString(jsonString.getBytes(StandardCharsets.UTF_8));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/utils/regexp/Patterns.java
+++ b/src/main/java/kr/hhplus/be/server/utils/regexp/Patterns.java
@@ -2,4 +2,5 @@ package kr.hhplus.be.server.utils.regexp;
 
 public class Patterns {
     public static final String UUID = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$";
+    public static final String BASE64 = "^[a-zA-Z0-9+/]*={0,2}$";
 }

--- a/src/test/java/kr/hhplus/be/server/tests/payment/integration/PaymentConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/tests/payment/integration/PaymentConcurrencyTest.java
@@ -12,7 +12,7 @@ import kr.hhplus.be.server.domain.queuetoken.service.QueueTokenService;
 import kr.hhplus.be.server.domain.reservation.entity.Reservation;
 import kr.hhplus.be.server.domain.reservation.service.ReservationService;
 import kr.hhplus.be.server.domain.user.entity.User;
-import kr.hhplus.be.server.tests.support.JpaRepositorySupport;
+import kr.hhplus.be.server.tests.support.InfraRepositorySupport;
 import kr.hhplus.be.server.utils.time.TimeProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
-public class PaymentConcurrencyTest extends JpaRepositorySupport {
+public class PaymentConcurrencyTest extends InfraRepositorySupport {
     @Autowired
     protected PaymentUseCase paymentUseCase;
 
@@ -76,7 +76,7 @@ public class PaymentConcurrencyTest extends JpaRepositorySupport {
 
         QueueToken token = QueueToken.createWaitingToken(user.getId(), concert.getId(), timeProvider);
         token.activate();
-        token = queueTokenJpaRepository.save(token);
+        token = queueTokenRepository.save(token);
         tokenUuid = token.getTokenUuid();
     }
 

--- a/src/test/java/kr/hhplus/be/server/tests/payment/integration/PaymentUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/tests/payment/integration/PaymentUseCaseTest.java
@@ -13,16 +13,9 @@ import kr.hhplus.be.server.domain.reservation.dto.ReservationResult;
 import kr.hhplus.be.server.domain.reservation.entity.Reservation;
 import kr.hhplus.be.server.domain.reservation.vo.ReservationStatus;
 import kr.hhplus.be.server.domain.user.entity.User;
-import kr.hhplus.be.server.infrastructure.concert.repository.ConcertJpaRepository;
-import kr.hhplus.be.server.infrastructure.concert.repository.ConcertScheduleJpaRepository;
-import kr.hhplus.be.server.infrastructure.concert.repository.SeatJpaRepository;
 import kr.hhplus.be.server.infrastructure.point.repository.PointHistoryJpaRepository;
-import kr.hhplus.be.server.infrastructure.point.repository.PointJpaRepository;
-import kr.hhplus.be.server.infrastructure.queuetoken.repository.QueueTokenJpaRepository;
-import kr.hhplus.be.server.infrastructure.reservation.repository.ReservationJpaRepository;
-import kr.hhplus.be.server.infrastructure.user.repository.UserJpaRepository;
+import kr.hhplus.be.server.tests.support.InfraRepositorySupport;
 import kr.hhplus.be.server.utils.time.TimeProvider;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,33 +30,12 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
 @SpringBootTest
-public class PaymentUseCaseTest {
+public class PaymentUseCaseTest extends InfraRepositorySupport {
     @Autowired
     private PaymentUseCase paymentUseCase;
 
     @Autowired
     private QueueTokenService queueTokenService;
-
-    @Autowired
-    private QueueTokenJpaRepository queueTokenJpaRepository;
-
-    @Autowired
-    private UserJpaRepository userJpaRepository;
-
-    @Autowired
-    private ConcertJpaRepository concertJpaRepository;
-
-    @Autowired
-    private ConcertScheduleJpaRepository concertScheduleJpaRepository;
-
-    @Autowired
-    private ReservationJpaRepository reservationJpaRepository;
-
-    @Autowired
-    private SeatJpaRepository seatJpaRepository;
-
-    @Autowired
-    private PointJpaRepository pointJpaRepository;
 
     @MockitoBean
     private PointHistoryJpaRepository pointHistoryJpaRepository;
@@ -83,23 +55,14 @@ public class PaymentUseCaseTest {
         user = userJpaRepository.save(User.create("test"));
         token = QueueToken.createWaitingToken(user.getId(), 1L, timeProvider);
         token.activate();
-        queueTokenJpaRepository.save(token);
+        queueTokenRepository.save(token);
+
         userPoint = Point.create(user);
         userPoint.plus(1_000_000);
         userPoint = pointJpaRepository.save(userPoint);
 
         concert = concertJpaRepository.save(Concert.create("test", timeProvider.now()));
         concertSchedule = concertScheduleJpaRepository.save(ConcertSchedule.create(concert, timeProvider.now().plusDays(1), 50));
-    }
-
-    @AfterEach
-    void tearDown() {
-        pointHistoryJpaRepository.deleteAll();
-        pointJpaRepository.deleteAll();
-        queueTokenJpaRepository.deleteAll();
-        reservationJpaRepository.deleteAll();
-        seatJpaRepository.deleteAll();
-        userJpaRepository.deleteAll();
     }
 
     @DisplayName("정상적으로 저장된 예약에 대해서 유효시간 안에 결제 요청 시 결제에 성공한다.")
@@ -120,7 +83,7 @@ public class PaymentUseCaseTest {
         assertThat(reservationResult.concertSeatResult().isAvailable()).isFalse();
         assertThat(pointJpaRepository.findById(userPoint.getId()).get().getBalance()).isEqualTo(1_000_000 - seat.getPrice());
         then(pointHistoryJpaRepository).should().save(any(PointHistory.class));
-        assertThat(queueTokenJpaRepository.findByTokenUuid(token.getTokenUuid())).isEmpty();
+        assertThat(queueTokenRepository.findByConcertIdAndTokenUuid(concert.getId(), token.getTokenUuid())).isEmpty();
     }
 
     @DisplayName("해당 임시 예약이 만료된 경우 결제에 실패하고, 좌석 상태 및 예약 상태가 변경된다.")

--- a/src/test/java/kr/hhplus/be/server/tests/queuetoken/integration/QueueTokenControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/tests/queuetoken/integration/QueueTokenControllerTest.java
@@ -6,6 +6,7 @@ import kr.hhplus.be.server.domain.queuetoken.dto.QueueTokenResult;
 import kr.hhplus.be.server.domain.queuetoken.service.QueueTokenService;
 import kr.hhplus.be.server.interfaces.api.queuetoken.controller.QueueTokenController;
 import kr.hhplus.be.server.interfaces.api.queuetoken.dto.QueueTokenRequest;
+import kr.hhplus.be.server.interfaces.utils.queuetoken.QueueTokenEncoder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -115,7 +116,7 @@ public class QueueTokenControllerTest {
 
         // when  // then
         mockMvc.perform(MockMvcRequestBuilders.get(uri)
-                .param("token", validToken.toString()))
+                .param("token", QueueTokenEncoder.base64EncodeToken(validToken, concertId)))
             .andExpect(status().isOk());
     }
 }

--- a/src/test/java/kr/hhplus/be/server/tests/queuetoken/integration/QueueTokenControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/tests/queuetoken/integration/QueueTokenControllerTest.java
@@ -102,15 +102,16 @@ public class QueueTokenControllerTest {
         // given
         String uri = "/queue/position";
         UUID validToken = UUID.randomUUID();
+        Long concertId = 100L;
 
         QueueTokenPositionResult mockResult = QueueTokenPositionResult.builder()
                 .tokenUuid(validToken)
                 .userId(1L)
-                .concertId(100L)
+                .concertId(concertId)
                 .position(1)
                 .remainingSeconds(1)
                 .build();
-        given(queueTokenService.getWaitingTokenPositionAndRemainingTime(validToken)).willReturn(mockResult);
+        given(queueTokenService.getWaitingTokenPositionAndRemainingTime(concertId, validToken)).willReturn(mockResult);
 
         // when  // then
         mockMvc.perform(MockMvcRequestBuilders.get(uri)

--- a/src/test/java/kr/hhplus/be/server/tests/queuetoken/integration/QueueTokenRepositoryTest.java
+++ b/src/test/java/kr/hhplus/be/server/tests/queuetoken/integration/QueueTokenRepositoryTest.java
@@ -3,7 +3,8 @@ package kr.hhplus.be.server.tests.queuetoken.integration;
 import kr.hhplus.be.server.domain.queuetoken.entity.QueueToken;
 import kr.hhplus.be.server.domain.queuetoken.entity.QueueTokenFactory;
 import kr.hhplus.be.server.domain.queuetoken.repository.QueueTokenRepository;
-import kr.hhplus.be.server.infrastructure.queuetoken.repository.QueueTokenJpaRepository;
+import kr.hhplus.be.server.infrastructure.queuetoken.repository.ActiveTokenRedisTemplate;
+import kr.hhplus.be.server.infrastructure.queuetoken.repository.WaitingTokenRedisTemplate;
 import kr.hhplus.be.server.utils.time.TimeProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,23 +12,23 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-@Transactional
 class QueueTokenRepositoryTest {
+
     @Autowired
-    private QueueTokenJpaRepository queueTokenJpaRepository;
+    private RedisTemplate<String, Object> redisTemplate;
 
     @Autowired
     private QueueTokenRepository queueTokenRepository;
@@ -35,24 +36,35 @@ class QueueTokenRepositoryTest {
     @Autowired
     private TimeProvider timeProvider;
 
+    @Autowired
+    private WaitingTokenRedisTemplate waitingTokenRedisTemplate;
+
+    @Autowired
+    private ActiveTokenRedisTemplate activeTokenRedisTemplate;
+
     long concertId = 101L;
+
+    QueueToken token1;
+    QueueToken token2;
+    QueueToken token3;
 
     @BeforeEach
     void setUp() throws InterruptedException {
-        QueueToken token1 = QueueToken.createWaitingToken(1L, concertId, timeProvider);
+        token1 = QueueToken.createWaitingToken(1L, concertId, timeProvider);
         Thread.sleep(1); // 1ms 지연
-        QueueToken token2 = QueueToken.createWaitingToken(2L, concertId, timeProvider);
+        token2 = QueueToken.createWaitingToken(2L, concertId, timeProvider);
         Thread.sleep(1); // 1ms 지연
-        QueueToken token3 = QueueToken.createWaitingToken(3L, concertId, timeProvider);
+        token3 = QueueToken.createWaitingToken(3L, concertId, timeProvider);
 
-        queueTokenJpaRepository.save(token1);
-        queueTokenJpaRepository.save(token2);
-        queueTokenJpaRepository.save(token3);
+        queueTokenRepository.save(token1);
+        queueTokenRepository.save(token2);
+        queueTokenRepository.save(token3);
     }
 
     @AfterEach
     void tearDown() {
-        queueTokenJpaRepository.deleteAll();
+        redisTemplate.delete(WaitingTokenRedisTemplate.getKey(concertId));
+        redisTemplate.delete(ActiveTokenRedisTemplate.getKey(concertId));
     }
 
     @Test
@@ -65,23 +77,57 @@ class QueueTokenRepositoryTest {
         QueueToken savedToken = queueTokenRepository.save(token);
 
         // then
-        Optional<QueueToken> retrievedToken = queueTokenJpaRepository.findById(savedToken.getId());
-        assertThat(retrievedToken).isPresent();
-        assertThat(retrievedToken.get().getTokenUuid()).isEqualTo(token.getTokenUuid());
+        Double score = waitingTokenRedisTemplate.getScore(concertId, savedToken.getTokenUuid());
+        assertThat(score).isNotNull();
     }
 
     @Test
     @DisplayName("Token UUID로 QueueToken을 검색하면 해당 토큰이 반환된다.")
-    void findByTokenUuid_shouldReturnMatchingToken() {
+    void findByConcertIdAndTokenUuid_shouldReturnMatchingToken() {
         // given
-        QueueToken token = queueTokenJpaRepository.findAll().get(0);
+        Set<Object> token = waitingTokenRedisTemplate.range(concertId, 0, 0);
+        UUID tokenUuid = UUID.fromString(token.iterator().next().toString());
 
         // when
-        Optional<QueueToken> foundToken = queueTokenRepository.findByTokenUuid(token.getTokenUuid());
+        Optional<QueueToken> foundToken = queueTokenRepository.findByConcertIdAndTokenUuid(concertId, tokenUuid);
 
         // then
         assertThat(foundToken).isPresent();
-        assertThat(foundToken.get().getId()).isEqualTo(token.getId());
+        assertThat(foundToken.get().getTokenUuid()).isEqualTo(tokenUuid);
+    }
+
+    @DisplayName("findByConcertIdAndTokenUuid로 waitingToken과 activeToken을 검색하면 각 상태에 맞는 토큰이 반환된다.")
+    @Test
+    void findByConcertIdAndTokenUuid_shouldReturnWaitingTokenAndActiveToken() {
+        // given
+        QueueToken waitingToken = QueueToken.createWaitingToken(1L, concertId, timeProvider);
+        queueTokenRepository.save(waitingToken);
+        QueueToken activeToken = QueueToken.createWaitingToken(2L, concertId, timeProvider);
+        activeToken.activate();
+        queueTokenRepository.save(activeToken);
+
+        // when
+        Optional<QueueToken> foundWaitingToken = queueTokenRepository.findByConcertIdAndTokenUuid(concertId, waitingToken.getTokenUuid());
+        Optional<QueueToken> foundActiveToken = queueTokenRepository.findByConcertIdAndTokenUuid(concertId, activeToken.getTokenUuid());
+
+        // then
+        assertThat(foundWaitingToken).isPresent();
+        assertThat(foundWaitingToken.get().isActive()).isFalse();
+        assertThat(foundActiveToken).isPresent();
+        assertThat(foundActiveToken.get().isActive()).isTrue();
+    }
+
+    @DisplayName("존재하지 않는 uuid로 findByConcertIdAndTokenUuid를 호출하면 빈 Optional을 반환한다.")
+    @Test
+    void findByConcertIdAndTokenUuid_shouldReturnEmptyOptionalWithNotExistingUuid() {
+        // given
+        UUID notExistingUuid = UUID.randomUUID();
+
+        // when
+        Optional<QueueToken> foundToken = queueTokenRepository.findByConcertIdAndTokenUuid(concertId, notExistingUuid);
+
+        // then
+        assertThat(foundToken).isEmpty();
     }
 
     @Test
@@ -89,78 +135,60 @@ class QueueTokenRepositoryTest {
     void deleteExpiredTokens_shouldRemoveExpiredTokens() {
         // given
         Clock mockClock = Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZoneId.systemDefault());
-        QueueToken token = QueueTokenFactory.createMock(UUID.randomUUID(), 4L, concertId, false, mockClock);
-        queueTokenJpaRepository.save(token);
+        QueueToken expiredToken = QueueTokenFactory.createMock(UUID.randomUUID(), 4L, concertId, false, mockClock);
+        queueTokenRepository.save(expiredToken);
 
         // when
-        queueTokenRepository.deleteExpiredTokens();
+        queueTokenRepository.deleteExpiredTokens(concertId);
 
         // then
-        List<QueueToken> tokens = queueTokenJpaRepository.findAll();
-        assertThat(tokens).allMatch(t -> !t.getExpiredAt().isBefore(LocalDateTime.now()));
+        Set<TypedTuple<Object>> tokens = waitingTokenRedisTemplate.rangeWithScores(concertId, 0, -1);
+        assertThat(tokens).hasSize(3);
+        assertThat(tokens).allMatch(t -> t.getScore() > Instant.now().toEpochMilli());  // 만료되지 않은 토큰만 남아있어야 함
     }
 
     @Test
     @DisplayName("활성화된 토큰의 개수를 정확히 반환한다.")
     void countActiveTokens_shouldReturnCorrectCount() {
         // 검증1: 활성화된 토큰이 없을 때 결과값 확인
-        int activeCount = queueTokenRepository.countActiveTokens();
+        int activeCount = queueTokenRepository.countActiveTokens(concertId);
         assertThat(activeCount).isEqualTo(0);
 
-        // 검증2: 토큰 하나를 활상화 상태로 변경 후 결과값 확인
-        QueueToken activeToken = queueTokenJpaRepository.findAll().get(0);
+        // 검증2: 활상화 상태의 토큰 1개를 저장 후 결과값 확인
+        QueueToken activeToken = QueueToken.createWaitingToken(1L, concertId, timeProvider);
         activeToken.activate();
-        queueTokenJpaRepository.save(activeToken);
+        queueTokenRepository.save(activeToken);
 
-        activeCount = queueTokenRepository.countActiveTokens();
+        activeCount = queueTokenRepository.countActiveTokens(concertId);
         assertThat(activeCount).isEqualTo(1);
     }
 
+    @DisplayName("""
+        activateTokensByConcertId를 호출하여 대기열에서 가장 오래된 2개의 토큰을 활성 토큰으로 전환한다.
+        이후, waiting 큐에 1개의 토큰이 남아있어야 하고, active 큐에 2개의 토큰이 있어야 한다.
+        """)
     @Test
-    @DisplayName("대기 중인 가장 오래된 토큰 ID를 제한된 개수만큼 반환한다.")
-    void findOldestWaitingTokensIds_shouldReturnOldestTokens() {
-        // 검증1: limit이 2일 때 가장 오래된 2개의 토큰 ID를 반환하는지 확인
-        List<Long> ids = queueTokenRepository.findOldestWaitingTokensIds(2);
-        assertThat(ids).hasSize(2);
+    void activateTokensByConcertIdTest(){
+        // when
+        queueTokenRepository.activateTokensByConcertId(concertId, 2);
 
-        List<QueueToken> tokens =  queueTokenJpaRepository.findAll();
-
-        // 검증2: 찾은 토큰들이 가장 오래된 토큰인지 확인
-        QueueToken oldestToken = queueTokenJpaRepository.findById(ids.get(0)).orElseThrow();
-        assertThat(oldestToken.getCreatedAt())
-                .isEqualTo(tokens.get(0).getCreatedAt());
-
-        QueueToken oldestToken2 = queueTokenJpaRepository.findById(ids.get(1)).orElseThrow();
-        assertThat(oldestToken2.getCreatedAt())
-                .isEqualTo(tokens.get(1).getCreatedAt());
-    }
-
-    @Test
-    @DisplayName("가장 오래된 대기 토큰을 활성화 상태로 업데이트한다.")
-    void updateOldestWaitingTokensToActive_shouldUpdateTokens() {
-        List<Long> ids = queueTokenRepository.findOldestWaitingTokensIds(2);
-        queueTokenRepository.updateOldestWaitingTokensToActive(ids);
-
-        QueueToken updatedToken1 = queueTokenJpaRepository.findById(ids.get(0)).orElseThrow();
-        assertThat(updatedToken1.isActive()).isTrue();
-        QueueToken updatedToken2 = queueTokenJpaRepository.findById(ids.get(1)).orElseThrow();
-        assertThat(updatedToken2.isActive()).isTrue();
-        QueueToken updatedToken3 = queueTokenJpaRepository.findAll().get(2);
-        assertThat(updatedToken3.isActive()).isFalse();
+        // then
+        assertThat(waitingTokenRedisTemplate.size(concertId)).isEqualTo(1);
+        assertThat(activeTokenRedisTemplate.size(concertId)).isEqualTo(2);
     }
 
     @Test
     @DisplayName("주어진 기준 시간 이전에 생성된 대기 상태인 토큰의 개수를 반환한다.")
-    void countWaitingTokensAhead_shouldReturnCorrectCount() {
+    void countWaitingTokensAhead_shouldReturnCorrectCount(){
         // 검증1: 가장 먼저 만들어진 토큰의 앞에 있는 토큰이 없으므로 0 반환
-        QueueToken firstToken = queueTokenJpaRepository.findAll().get(0);
-        int result1 = queueTokenRepository.countWaitingTokensAhead(firstToken.getConcertId(), firstToken.getCreatedAt());
+        Optional<QueueToken> firstToken = queueTokenRepository.findByConcertIdAndTokenUuid(token1.getConcertId(), token1.getTokenUuid());
+        int result1 = queueTokenRepository.countWaitingTokensAhead(firstToken.get());
 
         assertThat(result1).isEqualTo(0);
 
         // 검증2: 가장 나중에 만들어진 토큰의 앞에 있는 토큰은 나머지 전부 이므로 2 반환
-        QueueToken lastToken = queueTokenJpaRepository.findAll().get(2);
-        int result2 = queueTokenRepository.countWaitingTokensAhead(lastToken.getConcertId(), lastToken.getCreatedAt());
+        Optional<QueueToken> lastToken = queueTokenRepository.findByConcertIdAndTokenUuid(token3.getConcertId(), token3.getTokenUuid());
+        int result2 = queueTokenRepository.countWaitingTokensAhead(lastToken.get());
 
         assertThat(result2).isEqualTo(2);
     }

--- a/src/test/java/kr/hhplus/be/server/tests/reservation/integration/ReservationConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/tests/reservation/integration/ReservationConcurrencyTest.java
@@ -10,7 +10,7 @@ import kr.hhplus.be.server.domain.reservation.service.ReservationService;
 import kr.hhplus.be.server.domain.user.entity.User;
 import kr.hhplus.be.server.infrastructure.concert.repository.ConcertJpaRepository;
 import kr.hhplus.be.server.infrastructure.concert.repository.ConcertScheduleJpaRepository;
-import kr.hhplus.be.server.tests.support.JpaRepositorySupport;
+import kr.hhplus.be.server.tests.support.InfraRepositorySupport;
 import kr.hhplus.be.server.utils.time.TimeProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @SpringBootTest
-class ReservationConcurrencyTest extends JpaRepositorySupport {
+class ReservationConcurrencyTest extends InfraRepositorySupport {
     @Autowired
     ReservationUseCase reservationUseCase;
 

--- a/src/test/java/kr/hhplus/be/server/tests/support/InfraRepositorySupport.java
+++ b/src/test/java/kr/hhplus/be/server/tests/support/InfraRepositorySupport.java
@@ -1,19 +1,22 @@
 package kr.hhplus.be.server.tests.support;
 
+import kr.hhplus.be.server.domain.queuetoken.repository.QueueTokenRepository;
 import kr.hhplus.be.server.infrastructure.concert.repository.ConcertJpaRepository;
 import kr.hhplus.be.server.infrastructure.concert.repository.ConcertScheduleJpaRepository;
 import kr.hhplus.be.server.infrastructure.concert.repository.SeatJpaRepository;
 import kr.hhplus.be.server.infrastructure.point.repository.PointHistoryJpaRepository;
 import kr.hhplus.be.server.infrastructure.point.repository.PointJpaRepository;
-import kr.hhplus.be.server.infrastructure.queuetoken.repository.QueueTokenJpaRepository;
+import kr.hhplus.be.server.infrastructure.queuetoken.repository.ActiveTokenRedisTemplate;
+import kr.hhplus.be.server.infrastructure.queuetoken.repository.WaitingTokenRedisTemplate;
 import kr.hhplus.be.server.infrastructure.reservation.repository.ReservationJpaRepository;
 import kr.hhplus.be.server.infrastructure.user.repository.UserJpaRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
 
 @SpringBootTest
-public class JpaRepositorySupport {
+public class InfraRepositorySupport {
     @Autowired
     protected UserJpaRepository userJpaRepository;
 
@@ -36,7 +39,16 @@ public class JpaRepositorySupport {
     protected PointHistoryJpaRepository pointHistoryJpaRepository;
 
     @Autowired
-    protected QueueTokenJpaRepository queueTokenJpaRepository;
+    protected RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    protected ActiveTokenRedisTemplate activeTokenRedisTemplate;
+
+    @Autowired
+    protected WaitingTokenRedisTemplate waitingTokenRedisTemplate;
+
+    @Autowired
+    protected QueueTokenRepository queueTokenRepository;
 
     @AfterEach
     void tearDown() {
@@ -47,6 +59,6 @@ public class JpaRepositorySupport {
         concertScheduleJpaRepository.deleteAll();
         concertJpaRepository.deleteAll();
         userJpaRepository.deleteAll();
-        queueTokenJpaRepository.deleteAll();
+        redisTemplate.getConnectionFactory().getConnection().flushAll();
     }
 }


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->
우선, 각 커밋의 경계가 모호하다는 점을 말씀드립니다..

- Redis를 이용한 repository 구현: 8a3a43e
- 대기열 도메인 로직 변경 및 대기열 관련 테스트 코드 수정: 2825d5a
- [Redis로 이관에 관련한 보고서](https://github.com/yangahh/concert-ticket-reservation/wiki/10.-%EB%8C%80%EA%B8%B0%EC%97%B4-RDB%EC%97%90%EC%84%9C-Redis%EB%A1%9C-%EC%9D%B4%EA%B4%80)

---
### **리뷰 포인트(질문)**
- 커밋 히스토리가 중구난방이 되었습니다.. 죄송합니다ㅠ
- active 토큰 전환 로직을 '은행창구 방식'에서 '놀이동산 방식'으로 변경하였는데, "N초에 M개의 토큰을 전환한다"에서 N과 M의 값을 찾아가는 과정에 문제가 있는지 검토 부탁드립니다!
- RedisRepository를 추가하면서 기존의 코드를 많이 수정하기 되었습니다. 이렇다는건 기존의 코드가 jpa에 많이 의존하고 있었기 때문이겠죠..? 
- Token의 DB Entity를 날리지 않고 그냥 도메인 Entity로서 사용했는데, 이렇게 해도 괜찮은지 궁금합니다.

<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->

### Problem
<!--개선이 필요한 점-->

### Try
<!-- 새롭게 시도할 점 -->
